### PR TITLE
bump protocol version to 0.103.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [example project](https://github.com/ainvaltin/nu_plugin_plist) which implem
 commands to convert to/from plist and encode/decode base85.
 
 Nushell [protocol](https://www.nushell.sh/contributor-book/plugin_protocol_reference.html)
-`0.102.0`. Only message pack encoding is supported.
+`0.103.0`. Only message pack encoding is supported.
 
 ### Unsupported Engine Calls
 - GetConfig

--- a/config.go
+++ b/config.go
@@ -85,5 +85,5 @@ const (
 	format_mpack = "\x07msgpack"
 
 	protocol_name    = "nu-plugin"
-	protocol_version = "0.102.0"
+	protocol_version = "0.103.0"
 )


### PR DESCRIPTION
Did the bump version like in your last commit. The nushell release notes did not have any notes for plugin develpers.