### PR TITLE
bump protocol version to 0.108.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2026-02-13]
+- Plugin protocol version 0.108.0
+- Support for saving custom values to disk
+- Optional and casing information for FollowPath* functions
 
 ## [2025-06-11]
 - Plugin protocol version 0.105.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ using [Go](https://go.dev/).
 WIP. Good enough to write simple plugins.
 
 Nushell [protocol](https://www.nushell.sh/contributor-book/plugin_protocol_reference.html)
-`0.108.0`. Only message pack encoding is supported.
+`0.109.0`. Only message pack encoding is supported.
 
 ### Unsupported Engine Calls
 - GetConfig - the config struct type is a moving target.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ using [Go](https://go.dev/).
 WIP. Good enough to write simple plugins.
 
 Nushell [protocol](https://www.nushell.sh/contributor-book/plugin_protocol_reference.html)
-`0.107.0`. Only message pack encoding is supported.
+`0.108.0`. Only message pack encoding is supported.
 
 ### Unsupported Engine Calls
 - GetConfig - the config struct type is a moving target.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ using [Go](https://go.dev/).
 WIP. Good enough to write simple plugins.
 
 Nushell [protocol](https://www.nushell.sh/contributor-book/plugin_protocol_reference.html)
-`0.109.0`. Only message pack encoding is supported.
+`0.110.0`. Only message pack encoding is supported.
 
 ### Unsupported Engine Calls
 - GetConfig - the config struct type is a moving target.

--- a/call.go
+++ b/call.go
@@ -50,6 +50,8 @@ type (
 type (
 	empty struct{}
 
+	okResponse struct{}
+
 	// Value tuple variant as used by PipelineDataHeader
 	pipelineValue struct {
 		V Value
@@ -355,6 +357,12 @@ func (cr *callResponse) encodeMsgpack(enc *msgpack.Encoder, p *Plugin) error {
 		return dt.encodeMsgpack(enc, p)
 	case *pipelineData:
 		return dt.encodeMsgpack(enc, p)
+	case okResponse:
+		if err := encodeMapStart(enc, "Ok"); err != nil {
+			return err
+		}
+		var ret any = nil
+		return enc.EncodeValue(reflect.ValueOf(&ret))
 	case error:
 		return encodeErrorResponse(enc, flattenError(dt))
 	case metadata:

--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ Config is Plugin's configuration, mostly meant to allow debugging.
 type Config struct {
 	// whether to use "local socket mode" when supported. Defaults to
 	// true when nil config is used to create plugin.
-	//LocalSocket bool
+	// LocalSocket bool
 
 	// Logger the Plugin should use. If not provided the plugin will create
 	// Error level logger which logs to stderr.
@@ -85,5 +85,5 @@ const (
 	format_mpack = "\x07msgpack"
 
 	protocol_name    = "nu-plugin"
-	protocol_version = "0.107.0"
+	protocol_version = "0.108.0"
 )

--- a/config.go
+++ b/config.go
@@ -85,5 +85,5 @@ const (
 	format_mpack = "\x07msgpack"
 
 	protocol_name    = "nu-plugin"
-	protocol_version = "0.109.0"
+	protocol_version = "0.110.0"
 )

--- a/config.go
+++ b/config.go
@@ -85,5 +85,5 @@ const (
 	format_mpack = "\x07msgpack"
 
 	protocol_name    = "nu-plugin"
-	protocol_version = "0.108.0"
+	protocol_version = "0.109.0"
 )

--- a/custom.go
+++ b/custom.go
@@ -63,12 +63,14 @@ type CustomValue interface {
 	Dropped(ctx context.Context) error
 	// Returns the result of following a numeric cell path (e.g. $custom_value.0) on the custom value.
 	// This is most commonly used with custom types that act like lists or tables.
-	// The result may be another custom value.
-	FollowPathInt(ctx context.Context, item uint) (Value, error)
+	// The result may be another custom value. The parameter `optional` is used to control whether the
+	// path is optional.
+	FollowPathInt(ctx context.Context, item uint, optional bool) (Value, error)
 	// Returns the result of following a string cell path (e.g. $custom_value.field) on the custom value.
 	// This is most commonly used with custom types that act like lists or tables.
-	// The result may be another custom value.
-	FollowPathString(ctx context.Context, item string) (Value, error)
+	// The result may be another custom value. The parameters `optional` and `caseSensitive` are used to
+	// control whether the path is optional and whether the path is case sensitive.
+	FollowPathString(ctx context.Context, item string, optional, caseSensitive bool) (Value, error)
 	// Returns the result of evaluating an Operator on this custom value with another value.
 	// The rhs Value may be any value - not just the same custom value type.
 	// The result may be another custom value.
@@ -141,13 +143,16 @@ type (
 	toBaseValue struct{}
 
 	followPathInt struct {
-		Item uint `msgpack:"item"`
-		Span Span `msgpack:"span"`
+		Item     uint `msgpack:"item"`
+		Span     Span `msgpack:"span"`
+		Optional bool `msgpack:"optional"`
 	}
 
 	followPathString struct {
-		Item string `msgpack:"item"`
-		Span Span   `msgpack:"span"`
+		Item     string `msgpack:"item"`
+		Span     Span   `msgpack:"span"`
+		Optional bool   `msgpack:"optional"`
+		Casing   string `msgpack:"casing"`
 	}
 
 	partialCmp struct{ value Value }
@@ -164,6 +169,10 @@ type (
 		} `msgpack:"path"`
 	}
 )
+
+func (p followPathString) isCaseSensitive() bool {
+	return p.Casing == "Sensitive"
+}
 
 type customValueOp struct {
 	name string

--- a/examples/nu_plugin_bbolt/bolt_value.go
+++ b/examples/nu_plugin_bbolt/bolt_value.go
@@ -33,6 +33,10 @@ func (r boltValue) NotifyOnDrop() bool { return false }
 
 func (r boltValue) Dropped(ctx context.Context) error { return nil }
 
+func (r boltValue) Save(ctx context.Context, path string) error {
+	return fmt.Errorf("The save command is not implemented for custom value %s", r.Name())
+}
+
 func (r boltValue) FollowPathInt(ctx context.Context, item uint) (nu.Value, error) {
 	return nu.Value{}, fmt.Errorf("int path not supported")
 }

--- a/examples/nu_plugin_bbolt/bolt_value.go
+++ b/examples/nu_plugin_bbolt/bolt_value.go
@@ -37,11 +37,12 @@ func (r boltValue) Save(ctx context.Context, path string) error {
 	return fmt.Errorf("The save command is not implemented for custom value %s", r.Name())
 }
 
-func (r boltValue) FollowPathInt(ctx context.Context, item uint) (nu.Value, error) {
+func (r boltValue) FollowPathInt(ctx context.Context, item uint, optional bool) (nu.Value, error) {
 	return nu.Value{}, fmt.Errorf("int path not supported")
 }
 
-func (r boltValue) FollowPathString(ctx context.Context, item string) (nu.Value, error) {
+func (r boltValue) FollowPathString(ctx context.Context, item string, optional, caseSensitive bool) (nu.Value, error) {
+	// The optional and caseSensitive parameters are ignored in this implementation.
 	switch item {
 	case "db":
 		return nu.Value{Value: r.db.Path()}, nil

--- a/plugin.go
+++ b/plugin.go
@@ -213,6 +213,7 @@ func (p *Plugin) handleCall(ctx context.Context, msg call) error {
 }
 
 func (p *Plugin) handleCustomValueOp(ctx context.Context, callID int, cvOp customValueOp) error {
+	p.log.DebugContext(ctx, "handling custom value operation", "id", cvOp.id, "name", cvOp.name, "op", cvOp.op)
 	cv, ok := p.cvals[cvOp.id]
 	if !ok {
 		return fmt.Errorf("custom value operation on unknown variable {%s, %d} %T", cvOp.name, cvOp.id, cvOp.op)
@@ -242,6 +243,11 @@ func (p *Plugin) handleCustomValueOp(ctx context.Context, callID int, cvOp custo
 			return p.outputMsg(ctx, &callResponse{ID: callID, Response: err})
 		}
 		return p.outputMsg(ctx, &callResponse{ID: callID, Response: &pipelineData{Data: empty{}}})
+	case save:
+		if err := cv.Save(ctx, op.Path.Item); err != nil {
+			return p.outputMsg(ctx, &callResponse{ID: callID, Response: err})
+		}
+		return p.outputMsg(ctx, &callResponse{ID: callID, Response: okResponse{}})
 	default:
 		return fmt.Errorf("unknown custom value operation %T on %s", cvOp.op, cvOp.name)
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -231,9 +231,9 @@ func (p *Plugin) handleCustomValueOp(ctx context.Context, callID int, cvOp custo
 	case toBaseValue:
 		return handleResult(cv.ToBaseValue(ctx))
 	case followPathInt:
-		return handleResult(cv.FollowPathInt(ctx, op.Item))
+		return handleResult(cv.FollowPathInt(ctx, op.Item, op.Optional))
 	case followPathString:
-		return handleResult(cv.FollowPathString(ctx, op.Item))
+		return handleResult(cv.FollowPathString(ctx, op.Item, op.Optional, op.isCaseSensitive()))
 	case operation:
 		return handleResult(cv.Operation(ctx, op.op, op.value))
 	case partialCmp:


### PR DESCRIPTION
These commits implement the new features of the nushell protocol version 0.108.0:

- [Allow saving CustomValues](https://www.nushell.sh/blog/2025-10-15-nushell_v0_108_0.html#allow-saving-customvalues-16692-toc)
- [Pass optional and casing to follow path methods for CustomValue](https://www.nushell.sh/blog/2025-10-15-nushell_v0_108_0.html#pass-optional-and-casing-to-follow-path-methods-for-customvalue-16736-toc)

Plugins that use custom values need to implement the `Save` method. The signature of the `FollowPath*` methods was extended with `optional` and `caseSensitive` parameters analog to the `CellPath` methods.

I have added the new method and parameters to the `nu_plugin_bbolt`, but saving is not implemented and `optional` and `caseSensitive` are ignored for now.