### PR TITLE
Fix for stream metadata handling error

### DIFF
--- a/call.go
+++ b/call.go
@@ -541,6 +541,11 @@ func (md *pipelineMetadata) DecodeMsgpack(dec *msgpack.Decoder) error {
 				default:
 					return fmt.Errorf("unexpected value code %x for %q", c, key)
 				}
+			case "custom":
+				err := dec.Skip()
+				if err != nil {
+					return fmt.Errorf("skipping custom data: %w", err)
+				}
 			default:
 				return fmt.Errorf("unexpected metadata key %q", key)
 			}


### PR DESCRIPTION
When the received data of a web request is piped into a plugin function, the data may have additional metadata with key "custom". This leads to an error:

The command is taken from the Readme of my plugin ([https://github.com/gtnebel/nu_plugin_nuplot](https://github.com/gtnebel/nu_plugin_nuplot))

```nu
http get http://wttr.in/Berlin?format=j1
| get weather
| select date avgtempC
| each {|l| {date: ($l.date | into datetime) avgtempC: ($l.avgtempC | into int)} }
| nuplot bar --xaxis date --title "Weather forcast"
```

The plugin prints a lot of error messages (which are all subsequent errors of the first one) and then gets stuck.

```log
time=2026-02-20T18:19:10.834+01:00 level=ERROR msg="decoding top-level message" error="decoding Call Run: decoding Run map key \"input\": decoding ListStream: unexpected metadata key \"custom\""
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="decoding top-level message" error="unknown message \"http_response\""
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="decoding top-level message" error="unknown message \"Record\""
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="decoding top-level message" error="decode message's map: wrapper map is expected to contain one item, got 2"
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="handling message" error="unknown top-level message string" message=val
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="decoding top-level message" error="decode message's map: wrapper map is expected to contain one item, got 3"
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="handling message" error="unknown top-level message string" message=status
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="decoding top-level message" error="unknown message \"Int\""
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="decoding top-level message" error="decode message's map: wrapper map is expected to contain one item, got 2"
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="handling message" error="unknown top-level message string" message=val
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="handling message" error="unknown top-level message uint8" message=200
time=2026-02-20T18:19:10.835+01:00 level=ERROR msg="handling message" error="unknown top-level message string" message=span
...
```

When I call

```nu
http get http://wttr.in/Berlin?format=j1
| get weather
| select date avgtempC
| each {|l| {date: ($l.date | into datetime) avgtempC: ($l.avgtempC | into int)} }
| metadata | to json
```

to display the contained metadata it shows this:

```json
{
  "span": {
    "start": 154490,
    "end": 154494
  },
  "http_response": {
    "status": 200,
    "headers": [
      {
        "name": "access-control-allow-origin",
        "value": "*"
      },
      {
        "name": "content-type",
        "value": "application/json"
      },
      {
        "name": "content-length",
        "value": "50659"
      },
      {
        "name": "date",
        "value": "Fri, 20 Feb 2026 20:03:51 GMT"
      }
    ],
    "urls": [
      "http://wttr.in/Berlin?format=j1"
    ]
  }
}
```

The custom metadata is removed from the returned data if I save it to a variable. Then running `$res | nuplot bar --xaxis date --title "Weather forcast"` is ok. `$res | metadata | to json` gives

```json
{
  "span": {
    "start": 154490,
    "end": 154494
  }
}
```

My solution for the problem is to skip the custom metadata contained in the stream. If this data is useful for other plugins, it would be a better solution to actually parse it, but it is arbitrary structured data and I currently don't know how to handle it better.