### PR TITLE
Added new field `PathColumns` to pipeline metadata

### DIFF
--- a/call.go
+++ b/call.go
@@ -82,6 +82,7 @@ type (
 		FilePath    string // assigned when DataSource == FilePath
 		ContentType string
 		Custom      Record
+		PathColumns []string
 	}
 )
 
@@ -627,6 +628,10 @@ func (md *pipelineMetadata) decodeMsgpack(dec *msgpack.Decoder, p *Plugin) error
 			case "custom":
 				if md.Custom, err = decodeRecord(dec, p); err != nil {
 					return fmt.Errorf("decoding custom metadata record: %w", err)
+				}
+			case "path_columns":
+				if err = dec.Decode(&md.PathColumns); err != nil {
+					return fmt.Errorf("decoding path columns: %w", err)
 				}
 			default:
 				return fmt.Errorf("unexpected metadata key %q", key)


### PR DESCRIPTION
In nushell 0.111.0, when I call `open mydata.csv | nuplot line`, the plugin call fails with:

```
time=2026-03-02T15:20:39.818+01:00 level=ERROR msg="decoding top-level message" error="decoding Call Run: decoding Run map key \"input\": decoding ListStream: decoding listStream map key \"metadata\": unexpected metadata key \"path_columns\""
time=2026-03-02T15:20:39.819+01:00 level=ERROR msg="handling message" error="unknown top-level message []interface {}" message=[]
time=2026-03-02T15:20:39.819+01:00 level=ERROR msg="handling message" error="unknown top-level message string" message=content_type
time=2026-03-02T15:20:39.819+01:00 level=ERROR msg="handling message" error="unknown top-level message <nil>" message=<nil>
time=2026-03-02T15:20:39.819+01:00 level=ERROR msg="handling message" error="unknown top-level message string" message=custom
...
``` 

According to `help metadata set` the `path_columns` metadata key contains an array with column names which are treated as file paths. i.E. `ls | metadata` yields a `path_columns` metadata of `[name]`.

A new []string List `PathColumns` was added to the `pipelineMetadata` struct. The columns names in `path_columns` metadata are parsed into it.